### PR TITLE
INA3221 init: add probe parameter

### DIFF
--- a/adafruit_ina3221.py
+++ b/adafruit_ina3221.py
@@ -278,14 +278,15 @@ class INA3221Channel:
 class INA3221:
     """Driver for the INA3221 device with three channels."""
 
-    def __init__(self, i2c, address: int = DEFAULT_ADDRESS, enable: List = [0, 1, 2]) -> None:
+    def __init__(self, i2c, address: int = DEFAULT_ADDRESS, enable: List = [0, 1, 2], probe: bool = True) -> None:
         """Initializes the INA3221 class over I2C
         Args:
             i2c (I2C): The I2C bus to which the INA3221 is connected.
             address (int, optional): The I2C address of the INA3221. Defaults to DEFAULT_ADDRESS.
             enable(List[int], optional): channels to initialize at start (default: all)
+            probe (bool, optiona): Probe for the device upon object creation, default is true
         """
-        self.i2c_dev = I2CDevice(i2c, address)
+        self.i2c_dev = I2CDevice(i2c, address, probe=probe)
         self.reset()
 
         self.channels: List[INA3221Channel] = [INA3221Channel(self, i) for i in range(3)]

--- a/adafruit_ina3221.py
+++ b/adafruit_ina3221.py
@@ -278,7 +278,9 @@ class INA3221Channel:
 class INA3221:
     """Driver for the INA3221 device with three channels."""
 
-    def __init__(self, i2c, address: int = DEFAULT_ADDRESS, enable: List = [0, 1, 2], probe: bool = True) -> None:
+    def __init__(
+        self, i2c, address: int = DEFAULT_ADDRESS, enable: List = [0, 1, 2], probe: bool = True
+    ) -> None:
         """Initializes the INA3221 class over I2C
         Args:
             i2c (I2C): The I2C bus to which the INA3221 is connected.


### PR DESCRIPTION
Added option to disable i2c probing when creating the device instance.